### PR TITLE
Sparta 73/use old htaccess (#1)

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -2148,6 +2148,15 @@ function afterInstall()
     then
         appConfigImport
     fi
+
+    # Allow redirect from /support index
+    if versionIsHigherThan "$(getMagentoVersion)" "2.4.2"
+    then
+      CMD="sed -i '/RewriteRule\ .*\ \/pub\/\$0 \[L\]/d' .htaccess"
+      runCommand
+      CMD="cp pub/index.php index.php && sed -i 's/\/..\/app\/bootstrap.php/\/app\/bootstrap.php/g' index.php"
+      runCommand
+    fi
     warmCache
 }
 
@@ -2689,6 +2698,7 @@ function main()
     else
         magentoInstallAction;
     fi
+
     addStep "afterInstall"
     executeSteps "${STEPS[@]}"
 


### PR DESCRIPTION
From version 2.4.2 .htaccess as a diferent configuration and rewrites the /pub location and index.php is no longer present on the app root.
https://raw.githubusercontent.com/magento/magento2/2.4.2/.htaccess
Which affects the possibility of accessing the site from the index listed in /support :
https://web74.us-west-2.stg.sparta.ceng.magento.com/support/

This is a workaround in order to have the functionality restored.