### PR TITLE
New flags for --live-search and --prex

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -40,6 +40,7 @@ USE_SAMPLE_DATA=
 EE_PATH=magento2ee
 INSTALL_EE=
 INSTALL_B2B=
+INSTALL_PR=
 CONFIG_NAME=.m2install.conf
 USE_WIZARD=1
 
@@ -540,6 +541,10 @@ function noSourceWizard()
     then
          INSTALL_B2B=1
     fi
+    if askConfirmation "Do you want install Magento Product Recommendations (y/N)"
+    then
+         INSTALL_PR=1
+    fi
 }
 
 function printConfirmation()
@@ -592,6 +597,10 @@ function printConfirmation()
         printString "Magento B2B will be installed."
     else
         printString "Magento B2B will NOT be installed."
+    fi
+    if [ "${INSTALL_PR}" ]
+    then
+        printString "Magento Product Recommendations will be installed."
     fi
 }
 
@@ -676,6 +685,7 @@ DB_PASSWORD=$DB_PASSWORD
 MAGENTO_VERSION=$MAGENTO_VERSION
 INSTALL_EE=$INSTALL_EE
 INSTALL_B2B=$INSTALL_B2B
+INSTALL_PR=$INSTALL_PR
 GIT_CE_REPO=$GIT_CE_REPO
 GIT_EE_REPO=$GIT_EE_REPO
 MAGE_MODE=$MAGE_MODE
@@ -1681,6 +1691,24 @@ function installB2B()
     runCommand
 }
 
+function installPrex()
+{
+    CMD="${BIN_PHP} ${BIN_COMPOSER} require magento/product-recommendations"
+    runCommand
+
+    CMD="${BIN_PHP} ${BIN_MAGE} setup:upgrade"
+    runCommand
+    cat <<endmessage
+${yellow}
+####################################################################################
+Warning: Product Recommendations has been enabled.
+Please proceed to the API keys configuration and Catalog data synchronization:
+https://docs.magento.com/user-guide/configuration/services/saas.html
+####################################################################################
+${default}
+endmessage
+}
+
 function getB2Bversion()
 {
     checkIfBasedOnDevelopBranch && { B2B_VERSION="develop"; return 0; }
@@ -1953,7 +1981,10 @@ showComposerWizzard()
     then
         INSTALL_B2B=1
     fi
-
+    if askConfirmation "Do you want install Magento Product Recommendations (y/N)"
+    then
+        INSTALL_PR=1
+    fi
 }
 
 printComposerConfirmation()
@@ -1985,6 +2016,10 @@ function showWizzardGit()
     if [[ "$INSTALL_EE" ]] && askConfirmation "Do you want install B2B Extension (y/N)"
     then
         INSTALL_B2B=1
+    fi
+    if askConfirmation "Do you want install Magento Product Recommendations (y/N)"
+    then
+        INSTALL_PR=1
     fi
 }
 
@@ -2093,7 +2128,7 @@ function isInputNegative()
 function validateStep()
 {
     local _step=$1;
-    local _steps="restore_db restore_code configure_db configure_files configure installB2B installLiveSearch add_remote"
+    local _steps="restore_db restore_code configure_db configure_files configure installB2B installPrex add_remote"
     if echo "$_steps" | grep -q "$_step"
     then
         if type -t "$_step" &>/dev/null
@@ -2260,6 +2295,7 @@ Options:
     --sample-data (yes, no)              Install sample data.
     --ee                                 Install Enterprise Edition.
     --b2b                                Install B2B Extension.
+    --prex                               Install Product Recommendations.
     -v, --version                        Magento Version - it means: Composer version or GIT Branch
     --mode (dev, prod)                   Magento Mode. Dev mode does not generate static & di content.
     --quiet                              Quiet mode. Suppress output all commands
@@ -2268,6 +2304,7 @@ Options:
     --step (restore_code,restore_db      Specify step through comma without spaces.
         configure_db,configure_files     - Example: $(basename "$0") --step restore_db,configure_db
         installB2B --b2b                 - Example: $(basename "$0") --step installB2B --b2b
+        installPrex                      - Example: $(basename "$0") --step installPrex
         installLiveSearch)               - Example: $(basename "$0") --step installLiveSearch
     --restore-table                      Restore only the specific table from DB dumps
     --debug                              Enable debug mode
@@ -2327,6 +2364,9 @@ function processOptions()
                     B2B_VERSION="$2"
                     shift
                 fi
+            ;;
+            --prex)
+                INSTALL_PR=1
             ;;
             -b|--git-branch)
                 # @DEPRECATED. Use -v or --version instead
@@ -2480,6 +2520,10 @@ function magentoInstallAction()
     if [[ "$INSTALL_EE" ]] && [[ "$INSTALL_B2B" ]]
     then
         addStep "installB2B"
+    fi
+    if [[ "$INSTALL_PR" ]]
+    then
+        addStep "installPrex"
     fi
 }
 


### PR DESCRIPTION
As requested in [ACSD-46221](https://jira.corp.adobe.com/browse/ACSD-46221)

- `--live-search` flag added for already available `installLiveSearch` step
- new `installPrex` step and `--prex` flag added
