### PR TITLE
Revert 291c42f896d0da61125ec654ff6a67a42a8236cd commit

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -56,7 +56,7 @@ SOURCE=
 FORCE=
 MAGE_MODE=dev
 
-BIN_PHP=${BIN_PHP:"php"}
+BIN_PHP=php
 BIN_MAGE="-d memory_limit=4G bin/magento"
 BIN_COMPOSER=$(command -v composer)
 BIN_MYSQL="mysql"


### PR DESCRIPTION
This reverts commit 291c42f896d0da61125ec654ff6a67a42a8236cd.

Reverts changes which introduced the bug into m2install.sh:

**Steps to reproduce:**

1. Collect code and DB dumps
2. Navigate to folder which contains code and DB dumps archives. 
3. Run m2install.sh

**Actual result:**
`/usr/local/bin/m2install.sh: line 324: -r: command not found`
As a result m2install will produce output like the next during DB dump restoration:
```
ERROR 1046 (3D000) at line 7184: No database selected
ERROR 1046 (3D000) at line 7187: No database selected
ERROR 1046 (3D000) at line 7207: No database selected
ERROR 1046 (3D000) at line 7210: No database selected
```
**Expected result:**
m2install.sh should be able to determine DB name to run DB dump import without issues.

Link to the failing code line: https://github.com/yvoronoy/m2install/blob/master/m2install.sh#L324 