### PR TITLE
Fix: Magento_AdminAdobeImsTwoFactorAuth module blocks disabling Magento_TwoFactorAuth module

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -2262,6 +2262,7 @@ function afterInstall()
 
 function disableTwoFactorAuthModules()
 {
+    disableModule 'Magento_AdminAdobeImsTwoFactorAuth'
     disableModule 'Magento_TwoFactorAuth'
     disableModule 'MarkShust_DisableTwoFactorAuth'
     disableModule 'WolfSellers_EnableDisableTfa'


### PR DESCRIPTION
Fix: Magento_AdminAdobeImsTwoFactorAuth module blocks disabling Magento_TwoFactorAuth module, by disabling Magento_AdminAdobeImsTwoFactorAuth module as well.