### PR TITLE
SPARTA-521/SPARTA-533/SPARTA-537: add opensearch, error management and validations

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -2820,6 +2820,31 @@ function testParseMagentoVersion()
   assertEqual "2.2.4-p10" "$result"
 }
 
+validateWorkDirectory() {
+  # Exit if the script runs inside a home directory
+  if [[ ${PWD} == ${HOME} ]]; then
+    echo "The script cannot be executed in home directory"
+    echo "Please create a subdirectory and run script from there"
+    exit 1
+  fi
+
+  # Sparta specific checks
+  if [[ ${HOSTNAME} =~ sparta.ceng.magento.com$ ]]; then
+    # Exit if the script runs outside of public_html directory
+    if [[ ! ${PWD} =~ ^${HOME}/public_html* ]]; then
+      echo "The script cannot be executed outside of public_html directory"
+      echo "Please create a subdirectory in ${HOME}/public_html and run script from there"
+      exit 1
+    fi
+
+    # Exit if the script runs inside public_html directory without a subfolder
+    if [[ ${PWD} == ${HOME}/public_html ]]; then
+      echo "The script cannot be executed in public_html directory"
+      echo "Please create a subdirectory and run script from there"
+      exit 1
+    fi
+  fi
+}
 
 ################################################################################
 # Main
@@ -2840,6 +2865,7 @@ function main()
     processOptions "$@"
     initQuietMode
     printString Current Directory: "$(pwd)"
+    validateWorkDirectory
     printString "Configuration loaded from: $(getConfigFiles)"
     checkDependencies
     showWizard

--- a/m2install.sh
+++ b/m2install.sh
@@ -1837,7 +1837,14 @@ function installMagento()
       searchEngineBase="${searchEngine%[[:digit:]]}"
       CMD="${CMD} --search-engine=$searchEngine --${searchEngineBase}-host=$(getESConfigHost $searchEngine) --${searchEngineBase}-port=$(getESConfigPort $searchEngine) --${searchEngineBase}-index-prefix=${DB_NAME}"
     fi
-    runCommand
+
+    echo "${CMD}"
+    ${CMD}
+    if (( $? != 0 )); then
+      echo "bin/magento setup:install failed"
+      exit 1
+    fi
+
 }
 
 function isElasticSearchRequired()

--- a/m2install.sh
+++ b/m2install.sh
@@ -1995,13 +1995,18 @@ function downloadSourceCode()
 
 function composerInstall()
 {
-    if [ "$INSTALL_EE" ]
-    then
-        CMD="${BIN_PHP} ${BIN_COMPOSER} create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition . ${MAGENTO_VERSION}"
-        runCommand
+    if [ "$INSTALL_EE" ]; then
+        "${BIN_PHP}" "${BIN_COMPOSER}" create-project --repository-url='https://repo.magento.com/' magento/project-enterprise-edition ./ "${MAGENTO_VERSION}"
+        if (( $? != 0 )); then
+            echo "Failed to create a composer project"
+            exit 1
+        fi
     else
-        CMD="${BIN_PHP} ${BIN_COMPOSER} create-project --repository-url=https://repo.magento.com/ magento/project-community-edition . ${MAGENTO_VERSION}"
-        runCommand
+        "${BIN_PHP}" "${BIN_COMPOSER}" create-project --repository-url='https://repo.magento.com/' magento/project-community-edition ./ "${MAGENTO_VERSION}"
+        if (( $? != 0 )); then
+            echo "Failed to create a composer project"
+            exit 1
+        fi
     fi
 }
 


### PR DESCRIPTION
This PR adds:
* opensearch support
* check if script is running in $HOME directory
* check if script is running outside of ~/public_html/ directory on Sparta
* exit if composer create-project failed
* exit if setup:install failed