### PR TITLE
L2ACIP-335: fix Magento version parsing regex

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -2820,7 +2820,7 @@ function parseMagentoVersion()
   else
     valueToParse="$(${BIN_PHP} bin/magento -V)"
   fi
-  echo "$valueToParse" | grep -oEh "[0-9\.-]+p*[0-9]*" | head -n1
+  echo "$valueToParse" | grep -oEh "([0-9](\.)?){2,3}(-p[0-9]{1,2})?" | head -n1
 }
 
 


### PR DESCRIPTION
This change fixes the regexp used for parsing Magento version. It fixes how dev versions like `Magento CLI dev-2.4-develop` get parsed.

Details: https://jira.corp.adobe.com/browse/L2ACIP-335