### PR TITLE
L2ACIP-352: add Apache rewrite rules for serving PWA JS content

### DIFF
--- a/m2install.sh
+++ b/m2install.sh
@@ -1479,6 +1479,8 @@ function configurePWA()
         RewriteCond %{REQUEST_URI} \.(js|svg|woff|gif|woff2|png)$ [NC]\n
         RewriteCond %{DOCUMENT_ROOT}/${PWA}/%{REQUEST_URI} -f\n
         RewriteRule ^(.*\.(js|svg|woff|gif|woff2|png))$ /${PWA}/\$1 [L]\n
+        # Rewrite rule for redirecting requests to application webroot directory
+        RewriteRule .* /pub/$0 [L]
         # Set environment variables required for PWA\n
         SetEnv MAGENTO_BACKEND_URL ${BASE_URL}\n
         SetEnv NODE_ENV production\n

--- a/m2install.sh
+++ b/m2install.sh
@@ -1476,9 +1476,9 @@ function configurePWA()
         PWA="$(cat pwa_path.txt)"
         PWA_CONFIG="echo -e '
         # Rewrite rules for PWA JS files\n
-        RewriteCond %{REQUEST_URI} \.js$ [NC]\n
+        RewriteCond %{REQUEST_URI} \.(js|svg|woff|gif|woff2|png)$ [NC]\n
         RewriteCond %{DOCUMENT_ROOT}/${PWA}/%{REQUEST_URI} -f\n
-        RewriteRule ^(.*\.js)$ /${PWA}/\$1 [L]\n
+        RewriteRule ^(.*\.(js|svg|woff|gif|woff2|png))$ /${PWA}/\$1 [L]\n
         # Set environment variables required for PWA\n
         SetEnv MAGENTO_BACKEND_URL ${BASE_URL}\n
         SetEnv NODE_ENV production\n

--- a/m2install.sh
+++ b/m2install.sh
@@ -1475,9 +1475,14 @@ function configurePWA()
         echo "PWA setup"
         PWA="$(cat pwa_path.txt)"
         PWA_CONFIG="echo -e '
-        SetEnv MAGENTO_BACKEND_URL ${BASE_URL} \n
-        SetEnv NODE_ENV production \n
-        SetEnv CONFIG__DEFAULT__WEB__UPWARD__PATH ${ABSOLUTE_PATH}/${PWA}/upward.yml \n
+        # Rewrite rules for PWA JS files\n
+        RewriteCond %{REQUEST_URI} \.js$ [NC]\n
+        RewriteCond %{DOCUMENT_ROOT}/${PWA}/%{REQUEST_URI} -f\n
+        RewriteRule ^(.*\.js)$ /${PWA}/\$1 [L]\n
+        # Set environment variables required for PWA\n
+        SetEnv MAGENTO_BACKEND_URL ${BASE_URL}\n
+        SetEnv NODE_ENV production\n
+        SetEnv CONFIG__DEFAULT__WEB__UPWARD__PATH ${ABSOLUTE_PATH}/${PWA}/upward.yml\n
         '"
         CMD="${PWA_CONFIG} >> .htaccess "
         runCommand

--- a/m2install.sh
+++ b/m2install.sh
@@ -356,8 +356,7 @@ function prepareBaseURL()
 
     BASE_URL="${HTTP_HOST}${BASE_PATH}/"
     BASE_URL=$(echo ${BASE_URL} | sed "s/\/\/$/\//g" )
-    if isPubRequired
-    then
+    if [[ isPubRequired && ! -f pwa_path.txt ]]; then
         BASE_URL="${BASE_URL}pub/"
     fi
     BASE_URL=$(echo "$BASE_URL" | sed "s/\/\/$/\//g" );


### PR DESCRIPTION
This fix addresses issue with PWA dumps, after deployment a frontend isn't working because all the PWA related JS files are requested from the naked domain, e.g. example.com/clientxxxx.js, while those JS file are located in a subdirectory. This fix adds rewrite rules for Apache for redirecting request for PWA JS files to a PWA subdirectory.